### PR TITLE
Update SeaweedFS to 3.90

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 # Configuration
 EC_CONFIG ?= 9-3
-SEAWEEDFS_VERSION ?= 3.80
+SEAWEEDFS_VERSION ?= 3.90
 DOCKER_REGISTRY = ghcr.io
 GITHUB_ACTOR ?= $(shell whoami)
 GITHUB_REPOSITORY ?= $(GITHUB_ACTOR)/seaweedfs_ec


### PR DESCRIPTION
## 🔄 Automated SeaweedFS Version Update

This PR updates SeaweedFS from `3.80` to `3.90`.

### Changes
- Updated `SEAWEEDFS_VERSION` in Makefile
- This will trigger automatic Docker image builds for all EC configurations when merged

### What happens after merge:
1. ✅ New Docker images will be built for all available EC configurations
2. ✅ Multi-platform images (amd64) will be pushed to GHCR
3. ✅ Images will be tagged as both `3.90` and `latest`

### Available EC Configurations
This build will create images for all available configurations in the `Dockerfile.ec*` files.

### Release Notes
See [SeaweedFS Release Notes](https://github.com/seaweedfs/seaweedfs/releases/tag/3.90) for details on this version.

---
🤖 *This PR was created automatically by the SeaweedFS EC updater workflow.*